### PR TITLE
`sin` Addition Formula Optimization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,9 @@ const unsigned pinV_L = 18;
 const unsigned pinW_H = 17;
 const unsigned pinW_L = 16;
 
+const double sin_120 = 0.866025;
+const double sin_240 = -sin_120;
+
 void initialize_pins()
 {
 	const std::vector<unsigned> pins = {
@@ -57,9 +60,11 @@ void run_inverter(int N)
 	{
 		double x = 2 * M_PI * i / N;
 
-		double sU = std::sin(x);				// 0 degrees
-		double sV = std::sin(x + 2 * M_PI / 3); // 120 degrees
-		double sW = std::sin(x + 4 * M_PI / 3); // 240 degrees
+		double sU = std::sin(x);
+		double cosX = std::cos(x);
+		double sinAcosB = -(sU >> 1);
+		double sV = sinAcosB + sin_120 * cosX;
+		double sW = sinAcosB + sin_240 * cosX;
 
 		qeU += sU;
 		qeV += sV;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,6 @@ const unsigned pinW_H = 17;
 const unsigned pinW_L = 16;
 
 const double sin_120 = 0.866025;
-const double sin_240 = -sin_120;
 
 void initialize_pins()
 {
@@ -55,16 +54,25 @@ void run_inverter(int N)
 	double qeU = 0.0;
 	double qeV = 0.0;
 	double qeW = 0.0;
-
 	for (int i = 0; i < N; ++i)
 	{
+		/*
+		Instead of doing three trigonometric calculations, we can use the sine
+		addition formula to need only two trigonometric calculations:
+
+		sin(x + phi) = sin(x)cos(phi) + sin(phi)cos(x)
+
+		Because phi is a constant, we can precompute cos(phi) and sin(phi) so
+		that now we only perform two trigonometric calculations.
+		*/
+
 		double x = 2 * M_PI * i / N;
 
 		double sU = std::sin(x);
 		double cosX = std::cos(x);
-		double sinAcosB = -(sU >> 1);
+		double sinAcosB = sU * -0.5;
 		double sV = sinAcosB + sin_120 * cosX;
-		double sW = sinAcosB + sin_240 * cosX;
+		double sW = sinAcosB - sin_120 * cosX;
 
 		qeU += sU;
 		qeV += sV;


### PR DESCRIPTION
This implements the `sin` addition optimization for the SPDM signal production mentioned in #9 . Now, instead of performing three `sin` calculations, we only do two.

Testing this waveform (without the bit shifting, just multiplying by -0.5), provided a frequency of around 22 kHz, which although is lower than expected is still above the 20 kHz threshold. Additionally, the waveform was much cleaner than that from the Taylor series approximation and in fact, was exactly the same as what we had before any optimizations. This makes sense because of the addition formula, which is an equivalence, not an approximation.

I will test the code with the bit shifting after break.