### PR TITLE
Update setup instructions for macOS

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,18 +1,25 @@
 {
-  "configurations": [
-    {
-      "name": "Pico",
-      "includePath": [
-        "${workspaceFolder}/**",
-        "${env:PICO_SDK_PATH}/**"
-      ],
-      "defines": [],
-      "compilerPath": "${env:PICO_INSTALL_PATH}/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe",
-      "cStandard": "c11",
-      "cppStandard": "c++11",
-      "intelliSenseMode": "linux-gcc-arm",
-      "configurationProvider": "ms-vscode.cmake-tools"
-    }
-  ],
-  "version": 4
+	"configurations": [
+		{
+			"name": "Pico (Windows)",
+			"includePath": ["${workspaceFolder}/**", "${env:PICO_SDK_PATH}/**"],
+			"defines": [],
+			"compilerPath": "${env:PICO_INSTALL_PATH}/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe",
+			"cStandard": "c11",
+			"cppStandard": "c++17",
+			"intelliSenseMode": "linux-gcc-arm",
+			"configurationProvider": "ms-vscode.cmake-tools"
+		},
+		{
+			"name": "Pico (macOS)",
+			"includePath": ["${workspaceFolder}/**", "${env:PICO_SDK_PATH}/**"],
+			"defines": [],
+			"compilerPath": "/usr/local/bin/arm-none-eabi-gcc",
+			"cStandard": "c11",
+			"cppStandard": "c++17",
+			"intelliSenseMode": "linux-gcc-arm",
+			"configurationProvider": "ms-vscode.cmake-tools"
+		}
+	],
+	"version": 4
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,5 @@
   "cmake.configureSettings": {
     "CMAKE_MODULE_PATH": "${env:PICO_INSTALL_PATH}/pico-sdk-tools"
   },
-  "cmake.generator": "Ninja",
   "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
 }

--- a/README.md
+++ b/README.md
@@ -19,21 +19,14 @@ configuration that expedites the setup process.
 For Windows machines, a convenient installation tool is provided that installs
 all the necessary software for you. See [this article](https://www.raspberrypi.com/news/raspberry-pi-pico-windows-installer/) to download the installer.
 
-#### MacOS
+#### macOS
 
-For MacOS, a manual installation is required. Please make sure that Homebrew, a
-package manager for MacOS, is installed. If not, you can install it by running
-
-```shell
-$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-
-Then, run the following commands to install the rest of the required software:
+For macOS, CMake and the ARM compiler for the Raspberry Pi Pico can be installed from
+[Homebrew formulae](https://brew.sh).
 
 ```shell
 $ brew install cmake
-$ brew tap ArmMbed/homebrew-formulae
-$ brew install arm-none-eabi-gcc
+$ brew install gcc-arm-embedded
 ```
 
 #### Linux
@@ -95,9 +88,8 @@ Now that everything has been installed, it's time to build the program!
 Specifically, we will generate the UF2 executable that the Pico needs and
 manually copy this file over to the Pico.
 
-If you have the CMake extension installed, you can click "Build" on the
-bottom. The executable files for the Pico, including the UF2, will be
-automatically generated in the `build` directory.
+If you have the CMake extension installed, you can use the **Build** button in the status bar.
+The executable files for the Pico, including the UF2, will be compiled to the `build` directory.
 
 If you'd like to run the commands themselves, you can run the following:
 
@@ -109,9 +101,6 @@ $ make
 
 If errors occur, try restarting your terminal and then running the
 commands again.
-
-**For Windows devices, the `.vscode/` directory should automatically allow
-you to press the Build button that will do the above.**
 
 ## Running the Code
 


### PR DESCRIPTION
To allow developers on both macOS and Windows to use the C/C++ and CMake extensions for VS Code. Resolves #17.

## Changes
- Use new `gcc-arm-embedded` formulae for ARM compiler
- Provide C/C++ Configuration for developing on macOS
- Remove setting Ninja as CMake generator
- Clarify usage of Build button from CMake extension for VS Code

## Testing
1. Remove the `build` directory if it exists already
2. Use the **Build** button in the status bar from the CMake extension
3. Verify the program is compiled to `build`
4. Repeat steps for both macOS and Windows to ensure compatibility with both developer systems