### PR TITLE
Change pin output configuration for test circuit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,7 @@ void set_hilo_pins_(bool v)
 	}
 }
 
-constexpr void (*set_inverter_pins_)(bool v) = TEST_CIRCUIT ? set_logic_pin_ : set_hilo_pins_;
+constexpr auto& set_inverter_pins_ = TEST_CIRCUIT ? set_logic_pin_ : set_hilo_pins_;
 
 void run_one_inverter(int N)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,8 @@
 const unsigned pinU_H = 28;
 const unsigned pinU_L = 14;
 
+constexpr bool TEST_CIRCUIT = false;
+
 void initialize_pins()
 {
 	const std::vector<unsigned> pins = {
@@ -51,6 +53,27 @@ float calculate_frequency(float velocity)
 	return (u + velocity) * 2 * M_PI / L;
 }
 
+void set_logic_pin_(bool v) {
+	gpio_put(pinU_H, v);
+	gpio_put(pinU_L, 1);
+}
+
+void set_hilo_pins_(bool v)
+{
+	// Even though we should not need to manually introduce a delay (deadtime),
+	// we should still ensure that the rise always occurs after the fall on the
+	// GPIO pins for each phase.
+	if (v) {
+		gpio_put(pinU_L, !v);
+		gpio_put(pinU_H, v);
+	} else {
+		gpio_put(pinU_H, v);
+		gpio_put(pinU_L, !v);
+	}
+}
+
+constexpr void (*set_inverter_pins_)(bool v) = TEST_CIRCUIT ? set_logic_pin_ : set_hilo_pins_;
+
 void run_one_inverter(int N)
 {
 	float qe = 0.0;
@@ -61,7 +84,7 @@ void run_one_inverter(int N)
 		bool v = qe > 0;
 		int fix = v ? 1 : -1;
 		qe -= fix;
-		gpio_put(pinU_H, v);
+		set_inverter_pins_(v);
 	}
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,8 @@
 #include <cmath>
 #include <vector>
 
-const unsigned pinU_H = 21;
-const unsigned pinU_L = 20;
+const unsigned pinU_H = 28;
+const unsigned pinU_L = 14;
 
 void initialize_pins()
 {
@@ -51,20 +51,6 @@ float calculate_frequency(float velocity)
 	return (u + velocity) * 2 * M_PI / L;
 }
 
-void set_inverter_pins_(bool v, unsigned pin_H, unsigned pin_L)
-{
-	// Even though we should not need to manually introduce a delay (deadtime),
-	// we should still ensure that the rise always occurs after the fall on the
-	// GPIO pins for each phase.
-	if (v) {
-		gpio_put(pin_L, !v);
-		gpio_put(pin_H, v);
-	} else {
-		gpio_put(pin_H, v);
-		gpio_put(pin_L, !v);
-	}
-}
-
 void run_one_inverter(int N)
 {
 	float qe = 0.0;
@@ -75,7 +61,7 @@ void run_one_inverter(int N)
 		bool v = qe > 0;
 		int fix = v ? 1 : -1;
 		qe -= fix;
-		set_inverter_pins_(v, pinU_H, pinU_L);
+		gpio_put(pinU_H, v);
 	}
 }
 
@@ -83,6 +69,8 @@ int main()
 {
 	initialize_pins();
 	int frequency = 1000;
+
+	gpio_put(pinU_L, 1);
 
 	while (true)
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,16 +4,19 @@
 #include <cmath>
 #include <vector>
 
-const unsigned pinU_H = 28;
-const unsigned pinU_L = 14;
+const unsigned PIN_LOGIC = 28;
+const unsigned PIN_ENABLE = 14;
+
+const unsigned pin_H = 28;
+const unsigned pin_L = 14;
 
 constexpr bool TEST_CIRCUIT = false;
 
 void initialize_pins()
 {
 	const std::vector<unsigned> pins = {
-		pinU_H,
-		pinU_L};
+		PIN_LOGIC,
+		PIN_ENABLE};
 	for (unsigned pin : pins)
 	{
 		gpio_init(pin);
@@ -54,8 +57,8 @@ float calculate_frequency(float velocity)
 }
 
 void set_logic_pin_(bool v) {
-	gpio_put(pinU_H, v);
-	gpio_put(pinU_L, 1);
+	gpio_put(PIN_LOGIC, v);
+	gpio_put(PIN_ENABLE, 1);
 }
 
 void set_hilo_pins_(bool v)
@@ -64,11 +67,11 @@ void set_hilo_pins_(bool v)
 	// we should still ensure that the rise always occurs after the fall on the
 	// GPIO pins for each phase.
 	if (v) {
-		gpio_put(pinU_L, !v);
-		gpio_put(pinU_H, v);
+		gpio_put(pin_L, !v);
+		gpio_put(pin_H, v);
 	} else {
-		gpio_put(pinU_H, v);
-		gpio_put(pinU_L, !v);
+		gpio_put(pin_H, v);
+		gpio_put(pin_L, !v);
 	}
 }
 
@@ -92,8 +95,6 @@ int main()
 {
 	initialize_pins();
 	int frequency = 1000;
-
-	gpio_put(pinU_L, 1);
 
 	while (true)
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,9 +14,9 @@ constexpr bool TEST_CIRCUIT = false;
 
 void initialize_pins()
 {
-	const std::vector<unsigned> pins = {
-		PIN_LOGIC,
-		PIN_ENABLE};
+	const std::vector<unsigned> pins = TEST_CIRCUIT ? 
+		std::vector<unsigned>{PIN_LOGIC, PIN_ENABLE} :
+		std::vector<unsigned>{pin_H, pin_L};
 	for (unsigned pin : pins)
 	{
 		gpio_init(pin);


### PR DESCRIPTION
Resolves #26 by doing the following:

- Set high side pin to 28 and low side pin to 14, following the VFD schematic
- Add new global constant named `TEST_CIRCUIT` that dictates whether the test circuit gate driver or the VFD gate driver is being used
- Change the function named `set_inverter_pins_` to `set_hilo_pins_` and create a new function `set_logic_pin_` that outputs the high side signal and a constant 1
    - `set_hilo_pins_` will output the signals under the assumption that the VFD gate driver is being used while `set_logic_pin_` outputs signals assuming that the test circuit gate driver is being used
- Create a function pointer called `set_inverter_pins_` that points to either `set_hilo_pins_` or `set_logic_pin_` depending on the value of `TEST_CIRCUIT`