### PR TITLE
Implement serial control of velocity and throttle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ pico_add_extra_outputs(${PROJECT_NAME})
 # Link to pico_stdlib (gpio, time, etc. functions)
 target_link_libraries(${PROJECT_NAME} 
     pico_stdlib
+    pico_multicore
 )
 
 # Enable usb output, disable uart output

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 
 #include "pico/stdlib.h"
 #include "pico/multicore.h"
-#include "pico/sync.h"
+#include "pico/mutex.h"
 #include "hardware/gpio.h"
 #include "tusb.h"
 


### PR DESCRIPTION
As part of #37, allow continually outputting the PDM waveform with the last known parameters rather than just a single period. Using multicore functionality, a separate core monitors the serial input and updates the LIM control message through a mutex lock. We still need to implement expiration time for safety reasons.

## Changes
- Create a global variable to store the velocity and throttle
  - Add a mutex to prevent concurrent access to it
- Utilize Raspberry Pi Pico's second core to run a function to read input and update the global variable