### PR TITLE
Disable inverter when no output is desired

### DIFF
--- a/include/pin_logic.hpp
+++ b/include/pin_logic.hpp
@@ -12,11 +12,9 @@ constexpr bool TEST_CIRCUIT = false;
 void initialize_pins();
 
 void set_logic_pin_(bool v);
-
 void set_hilo_pins_(bool v);
 
 void set_logic_off_();
-
 void set_hilo_pins_off_();
 
 static constexpr auto& set_inverter_pins_ = TEST_CIRCUIT ? set_logic_pin_ : set_hilo_pins_;

--- a/include/pin_logic.hpp
+++ b/include/pin_logic.hpp
@@ -1,0 +1,25 @@
+#ifndef PIN_LOGIC_HPP
+#define PIN_LOGIC_HPP
+
+const unsigned PIN_LOGIC = 28;
+const unsigned PIN_ENABLE = 14;
+
+const unsigned pin_H = 28;
+const unsigned pin_L = 14;
+
+constexpr bool TEST_CIRCUIT = false;
+
+void initialize_pins();
+
+void set_logic_pin_(bool v);
+
+void set_hilo_pins_(bool v);
+
+void set_logic_off_();
+
+void set_hilo_pins_off_();
+
+static constexpr auto& set_inverter_pins_ = TEST_CIRCUIT ? set_logic_pin_ : set_hilo_pins_;
+static constexpr auto& set_inverter_off_ = TEST_CIRCUIT ? set_logic_off_ : set_hilo_pins_off_;
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,20 @@ void set_hilo_pins_(bool v)
 	}
 }
 
+void set_logic_off_()
+{
+	gpio_put(PIN_LOGIC, 0);
+	gpio_put(PIN_ENABLE, 0);
+}
+
+void set_hilo_pins_off_()
+{
+	gpio_put(pin_H, 0);
+	gpio_put(pin_L, 0);
+}
+
 constexpr auto& set_inverter_pins_ = TEST_CIRCUIT ? set_logic_pin_ : set_hilo_pins_;
+constexpr auto& set_inverter_off_ = TEST_CIRCUIT ? set_logic_off_ : set_hilo_pins_off_;
 
 void run_inverter_cycle(int N, float amplitude)
 {
@@ -135,6 +148,11 @@ void run_inverter()
 		mutex_exit(&lcmMutex);
 
 		// TODO: disregard zero frequency
+		if (frequency == 0)
+		{
+			set_inverter_off_();
+			continue;
+		}
 
 		int N = frequency_to_samples(frequency);
 		// TODO: amplitude ratio

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,43 +1,20 @@
 #include <cmath>
-#include <vector>
 
-#include "pico/stdlib.h"
 #include "pico/multicore.h"
 #include "pico/mutex.h"
 #include "hardware/gpio.h"
 #include "tusb.h"
 
+#include "pin_logic.hpp"
 #include "pod_communication.hpp"
-
-const unsigned PIN_LOGIC = 28;
-const unsigned PIN_ENABLE = 14;
-
-const unsigned pin_H = 28;
-const unsigned pin_L = 14;
 
 const float OPERATING_FREQUENCY = 45552.3;
 const float OFFSET = 0.0411;
-
-constexpr bool TEST_CIRCUIT = false;
 
 // Value will be changed by other core, so prevent compiler from optimizing as constant
 volatile static LimControlMessage lcm{ 0, 1 };
 // Allow only one core at a time to access lcm
 static mutex lcmMutex;
-
-
-void initialize_pins()
-{
-	const std::vector<unsigned> pins = TEST_CIRCUIT ?
-		std::vector<unsigned>{PIN_LOGIC, PIN_ENABLE} :
-		std::vector<unsigned>{ pin_H, pin_L };
-
-	for (unsigned pin : pins)
-	{
-		gpio_init(pin);
-		gpio_set_dir(pin, GPIO_OUT);
-	}
-}
 
 float calculate_frequency(float velocity, float throttle)
 {
@@ -66,44 +43,6 @@ float calculate_frequency(float velocity, float throttle)
 
 	return (slip + velocity) * 2 * M_PI / L;
 }
-
-void set_logic_pin_(bool v)
-{
-	gpio_put(PIN_LOGIC, v);
-	gpio_put(PIN_ENABLE, 1);
-}
-
-void set_hilo_pins_(bool v)
-{
-	// Even though we should not need to manually introduce a delay (deadtime),
-	// we should still ensure that the rise always occurs after the fall on the
-	// GPIO pins for each phase.
-	if (v)
-	{
-		gpio_put(pin_L, !v);
-		gpio_put(pin_H, v);
-	}
-	else
-	{
-		gpio_put(pin_H, v);
-		gpio_put(pin_L, !v);
-	}
-}
-
-void set_logic_off_()
-{
-	gpio_put(PIN_LOGIC, 0);
-	gpio_put(PIN_ENABLE, 0);
-}
-
-void set_hilo_pins_off_()
-{
-	gpio_put(pin_H, 0);
-	gpio_put(pin_L, 0);
-}
-
-constexpr auto& set_inverter_pins_ = TEST_CIRCUIT ? set_logic_pin_ : set_hilo_pins_;
-constexpr auto& set_inverter_off_ = TEST_CIRCUIT ? set_logic_off_ : set_hilo_pins_off_;
 
 void run_inverter_cycle(int N, float amplitude)
 {
@@ -147,7 +86,7 @@ void run_inverter()
 		float frequency = calculate_frequency(lcm.velocity, lcm.throttle);
 		mutex_exit(&lcmMutex);
 
-		// TODO: disregard zero frequency
+		// Set pins to low if frequency is zero
 		if (frequency == 0)
 		{
 			set_inverter_off_();

--- a/src/pin_logic.cpp
+++ b/src/pin_logic.cpp
@@ -1,53 +1,54 @@
+#include "pin_logic.hpp"
+
 #include <vector>
 
 #include "pico/stdlib.h"
 
-#include "pin_logic.hpp"
 
 void initialize_pins()
 {
-    const std::vector<unsigned> pins = TEST_CIRCUIT ?
-        std::vector<unsigned>{PIN_LOGIC, PIN_ENABLE} :
-        std::vector<unsigned>{ pin_H, pin_L };
+	const std::vector<unsigned> pins = TEST_CIRCUIT ?
+		std::vector<unsigned>{PIN_LOGIC, PIN_ENABLE} :
+		std::vector<unsigned>{ pin_H, pin_L };
 
-    for (unsigned pin : pins)
-    {
-        gpio_init(pin);
-        gpio_set_dir(pin, GPIO_OUT);
-    }
+	for (unsigned pin : pins)
+	{
+		gpio_init(pin);
+		gpio_set_dir(pin, GPIO_OUT);
+	}
 }
 
 void set_logic_pin_(bool v)
 {
-    gpio_put(PIN_LOGIC, v);
-    gpio_put(PIN_ENABLE, 1);
+	gpio_put(PIN_LOGIC, v);
+	gpio_put(PIN_ENABLE, 1);
 }
 
 void set_hilo_pins_(bool v)
 {
-    // Even though we should not need to manually introduce a delay (deadtime),
-    // we should still ensure that the rise always occurs after the fall on the
-    // GPIO pins for each phase.
-    if (v)
-    {
-        gpio_put(pin_L, !v);
-        gpio_put(pin_H, v);
-    }
-    else
-    {
-        gpio_put(pin_H, v);
-        gpio_put(pin_L, !v);
-    }
+	// Even though we should not need to manually introduce a delay (deadtime),
+	// we should still ensure that the rise always occurs after the fall on the
+	// GPIO pins for each phase.
+	if (v)
+	{
+		gpio_put(pin_L, !v);
+		gpio_put(pin_H, v);
+	}
+	else
+	{
+		gpio_put(pin_H, v);
+		gpio_put(pin_L, !v);
+	}
 }
 
 void set_logic_off_()
 {
-    gpio_put(PIN_LOGIC, 0);
-    gpio_put(PIN_ENABLE, 0);
+	gpio_put(PIN_LOGIC, 0);
+	gpio_put(PIN_ENABLE, 0);
 }
 
 void set_hilo_pins_off_()
 {
-    gpio_put(pin_H, 0);
-    gpio_put(pin_L, 0);
+	gpio_put(pin_H, 0);
+	gpio_put(pin_L, 0);
 }

--- a/src/pin_logic.cpp
+++ b/src/pin_logic.cpp
@@ -1,0 +1,53 @@
+#include <vector>
+
+#include "pico/stdlib.h"
+
+#include "pin_logic.hpp"
+
+void initialize_pins()
+{
+    const std::vector<unsigned> pins = TEST_CIRCUIT ?
+        std::vector<unsigned>{PIN_LOGIC, PIN_ENABLE} :
+        std::vector<unsigned>{ pin_H, pin_L };
+
+    for (unsigned pin : pins)
+    {
+        gpio_init(pin);
+        gpio_set_dir(pin, GPIO_OUT);
+    }
+}
+
+void set_logic_pin_(bool v)
+{
+    gpio_put(PIN_LOGIC, v);
+    gpio_put(PIN_ENABLE, 1);
+}
+
+void set_hilo_pins_(bool v)
+{
+    // Even though we should not need to manually introduce a delay (deadtime),
+    // we should still ensure that the rise always occurs after the fall on the
+    // GPIO pins for each phase.
+    if (v)
+    {
+        gpio_put(pin_L, !v);
+        gpio_put(pin_H, v);
+    }
+    else
+    {
+        gpio_put(pin_H, v);
+        gpio_put(pin_L, !v);
+    }
+}
+
+void set_logic_off_()
+{
+    gpio_put(PIN_LOGIC, 0);
+    gpio_put(PIN_ENABLE, 0);
+}
+
+void set_hilo_pins_off_()
+{
+    gpio_put(pin_H, 0);
+    gpio_put(pin_L, 0);
+}


### PR DESCRIPTION
Resolves #38.

## Changes
- Create new functions that set output pins to low
- Add new ternary to choose the function to run based on whether testing is enabled or not
- Modify `run_inverter` while loop to run the chosen function if the calculated frequency is 0