### PR TITLE
 Add control message expiration time

### DIFF
--- a/include/pod_communication.hpp
+++ b/include/pod_communication.hpp
@@ -1,10 +1,13 @@
 #ifndef POD_COMMUNICATION_HPP
 #define POD_COMMUNICATION_HPP
 
+#include "pico/time.h"
+
 struct LimControlMessage
 {
 	float velocity;
 	float throttle;
+	absolute_time_t messageTime;
 };
 
 LimControlMessage read_control_message();

--- a/src/pod_communication.cpp
+++ b/src/pod_communication.cpp
@@ -7,8 +7,5 @@ LimControlMessage read_control_message()
 	float throttle;
 	std::cin >> velocity >> throttle;
 
-	std::cout << "Received velocity: " << velocity << std::endl;
-	std::cout << "Received throttle: " << throttle << std::endl;
-
-	return { velocity, throttle };
+	return { velocity, throttle, get_absolute_time() };
 }


### PR DESCRIPTION
Resolves #37.

## Changes
- Use `absolute_time_diff_us` from `pico/time.h` to calculate difference between last received message and the current time
  - If the difference is greater than the threshold of `EXPIRATION_TIME`, set the frequency to be zero
- Refactor `monitor_serial` to directly assign to `lcm` rather than assigning by attribute